### PR TITLE
Issue #37: Fix geofield dropdown.

### DIFF
--- a/src/Plugin/views/style/GeoJson.php
+++ b/src/Plugin/views/style/GeoJson.php
@@ -225,7 +225,7 @@ class GeoJson extends StylePluginBase {
         '#type' => 'select',
         '#title' => t('Geofield'),
         '#description' => t("Choose a Geofield field. Any formatter will do; we'll access Geofield's underlying WKT format."),
-        '#options' => $fields,
+        '#options' => $geofield_fields,
         '#default_value' => $this->options['data_source']['geofield'],
         '#states' => array(
           'visible' => array(


### PR DESCRIPTION
This PR sets the available fields in the geofields dropdown to be only those fields which are actually of type geofield. I have no idea why it wasn't in the code before!!