### PR TITLE
Include FormStateInterface in views plugin

### DIFF
--- a/src/Plugin/views/argument_default/BBoxQuery.php
+++ b/src/Plugin/views/argument_default/BBoxQuery.php
@@ -5,6 +5,7 @@ namespace Drupal\views_geojson\Plugin\views\argument_default;
 
 // TODO: Which need to be included?
 use Drupal\views\Plugin\views\argument_default\QueryParameter;
+use \Drupal\core\form\FormStateInterface;
 
 // TODO: What should be included in annotations?
 /**


### PR DESCRIPTION
@kostajh Some background: I've had many issues using Views in our Drupal 8 beta 10 instance. One problem was this missing include statement, which was preventing me from adding contextual filters in Views involving the Place content type, which uses Views GeoJSON. 

PHPCS told me that FormStateInterface was undefined and adding the `use` statement solved my Views problem. 